### PR TITLE
[Feat] 경험치 정책에 의한 레벨업 API 구현

### DIFF
--- a/src/main/java/com/easystock/backend/application/service/level/LevelService.java
+++ b/src/main/java/com/easystock/backend/application/service/level/LevelService.java
@@ -1,0 +1,8 @@
+package com.easystock.backend.application.service.level;
+
+import com.easystock.backend.infrastructure.database.entity.enums.LevelType;
+import com.easystock.backend.presentation.api.dto.response.LevelUpResponse;
+
+public interface LevelService {
+    LevelUpResponse levelUpIfPossible(Long memberId);
+}

--- a/src/main/java/com/easystock/backend/application/service/level/LevelServiceImpl.java
+++ b/src/main/java/com/easystock/backend/application/service/level/LevelServiceImpl.java
@@ -1,0 +1,50 @@
+package com.easystock.backend.application.service.level;
+
+import com.easystock.backend.aspect.exception.LevelException;
+import com.easystock.backend.aspect.exception.QuizException;
+import com.easystock.backend.infrastructure.database.entity.Member;
+import com.easystock.backend.infrastructure.database.entity.enums.LevelType;
+import com.easystock.backend.infrastructure.database.repository.MemberRepository;
+import com.easystock.backend.presentation.api.dto.converter.MemberConverter;
+import com.easystock.backend.presentation.api.dto.response.LevelUpResponse;
+import com.easystock.backend.presentation.api.payload.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @RequiredArgsConstructor
+public class LevelServiceImpl implements LevelService {
+    private final MemberRepository memberRepository;
+    @Override
+    @Transactional
+    public LevelUpResponse levelUpIfPossible(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new QuizException(ErrorStatus.MEMBER_NOT_FOUND));
+        int xpGauge = member.getXpGauge();
+
+        boolean isTutorialCompleted = member.getIsTutorialCompleted();
+        boolean isQuizCompleted = member.getIsQuizCompleted();
+        LevelType currentLevel = member.getLevel();
+
+        if(!isTutorialCompleted && !isQuizCompleted)
+            throw new LevelException(ErrorStatus.LEVELUP_CONDITION_UNSATISFIED);
+
+        LevelType nextLevel = calculateNextLevel(currentLevel, xpGauge);
+        if(nextLevel == null)
+            throw new LevelException(ErrorStatus.LEVELUP_CONDITION_UNSATISFIED);
+        memberRepository.improveLevel(memberId, nextLevel);
+        return MemberConverter.toLevelUpResDto(nextLevel);
+    }
+
+    private LevelType calculateNextLevel(LevelType currentLevel, int xpGauge) {
+        return switch (currentLevel) {
+            case ZERO -> xpGauge >= 50 ? LevelType.ONE : null;
+            case ONE -> xpGauge >= 200 ? LevelType.TWO : null;
+            case TWO -> xpGauge >= 600 ? LevelType.THREE : null;
+            case THREE -> xpGauge >= 1000 ? LevelType.FOUR : null;
+            case FOUR -> xpGauge >= 2000 ? LevelType.FIVE : null;
+            case FIVE -> xpGauge >= 3500 ? LevelType.SIX : null;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/easystock/backend/application/service/level/LevelServiceImpl.java
+++ b/src/main/java/com/easystock/backend/application/service/level/LevelServiceImpl.java
@@ -33,6 +33,7 @@ public class LevelServiceImpl implements LevelService {
         if(nextLevel == null)
             throw new LevelException(ErrorStatus.LEVELUP_CONDITION_UNSATISFIED);
         memberRepository.improveLevel(memberId, nextLevel);
+        memberRepository.addRewardTokens(memberId, 3000);
         return MemberConverter.toLevelUpResDto(nextLevel);
     }
 

--- a/src/main/java/com/easystock/backend/application/service/quiz/QuizService.java
+++ b/src/main/java/com/easystock/backend/application/service/quiz/QuizService.java
@@ -9,5 +9,4 @@ import java.util.List;
 public interface QuizService {
     Quiz getQuizProblem(Long memberId);
     QuizSubmitResponse submitAnswer(Long memberId, Long quizId, int inputIndex);
-    void levelUpIfPossible(Long memberId, LevelType levelType);
 }

--- a/src/main/java/com/easystock/backend/application/service/quiz/QuizServiceImpl.java
+++ b/src/main/java/com/easystock/backend/application/service/quiz/QuizServiceImpl.java
@@ -30,7 +30,9 @@ public class QuizServiceImpl implements QuizService{
                 .orElseThrow(()-> new QuizException(ErrorStatus.MEMBER_NOT_FOUND));
         LevelType levelType = member.getLevel();
         List<Quiz> quizzes = memberQuizRepository.findUncompletedQuizProblemsByLevel(memberId, levelType);
-        if(quizzes.isEmpty()) throw new QuizException(ErrorStatus.QUIZ_NOT_FOUND);
+
+        if(quizzes.isEmpty())
+            throw new QuizException(ErrorStatus.QUIZ_NOT_FOUND);
 
         Quiz nextQuiz= quizzes.get(0);
         boolean exists = memberQuizRepository.existsByMemberIdAndQuizId(memberId, nextQuiz.getId());
@@ -48,7 +50,7 @@ public class QuizServiceImpl implements QuizService{
 
         if (memberQuiz.isCompleted()) {
             int totalXp = memberRepository.findById(memberId).orElseThrow().getXpGauge();
-            return QuizConverter.toQuizSubmitResDto(false, 0, totalXp);
+            return QuizConverter.toQuizSubmitResDto(false, false, 0, totalXp);
         }
 
         Quiz quiz = quizRepository.findById(quizId)
@@ -62,35 +64,24 @@ public class QuizServiceImpl implements QuizService{
             memberQuizRepository.updateQuizAsCompleted(memberId, quizId);
         }
 
-        int totalXp = memberRepository.findById(memberId).orElseThrow().getXpGauge();
-        return QuizConverter.toQuizSubmitResDto(isCorrect, addedXp, totalXp);
-    }
+        int totalXp = memberRepository.findById(memberId)
+                .orElseThrow(() -> new QuizException(ErrorStatus.MEMBER_NOT_FOUND))
+                .getXpGauge();
 
-    @Override
-    @Transactional
-    public void levelUpIfPossible(Long memberId, LevelType levelType) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new QuizException(ErrorStatus.MEMBER_NOT_FOUND));
-        int xpGauge = member.getXpGauge();
-
-        boolean isTutorialCompleted = member.getIsTutorialCompleted();
-        if(!isTutorialCompleted) return;
-        LevelType nextLevel = calculateNextLevel(levelType, xpGauge);
-        if(nextLevel != null){
-            memberRepository.improveLevel(memberId, nextLevel);
+        boolean allQuizProblemsSolved = false;
+        try {
+            getQuizProblem(memberId);
+        } catch (QuizException e){
+            if(e.getErrorStatus() == ErrorStatus.QUIZ_NOT_FOUND) {
+                allQuizProblemsSolved = true;
+            } else {
+                throw e;
+            }
         }
-    }
-
-    private LevelType calculateNextLevel(LevelType currentLevel, int xpGauge) {
-        return switch (currentLevel) {
-            case ZERO -> xpGauge >= 50 ? LevelType.ONE : null;
-            case ONE -> xpGauge >= 200 ? LevelType.TWO : null;
-            case TWO -> xpGauge >= 600 ? LevelType.THREE : null;
-            case THREE -> xpGauge >= 1000 ? LevelType.FOUR : null;
-            case FOUR -> xpGauge >= 2000 ? LevelType.FIVE : null;
-            case FIVE -> xpGauge >= 3500 ? LevelType.SIX : null;
-            default -> null;
-        };
+        if(allQuizProblemsSolved){
+            memberRepository.updateQuizStatus(allQuizProblemsSolved);
+        }
+        return QuizConverter.toQuizSubmitResDto(isCorrect, allQuizProblemsSolved, addedXp, totalXp);
     }
 
 }

--- a/src/main/java/com/easystock/backend/aspect/exception/LevelException.java
+++ b/src/main/java/com/easystock/backend/aspect/exception/LevelException.java
@@ -1,0 +1,7 @@
+package com.easystock.backend.aspect.exception;
+
+import com.easystock.backend.presentation.api.payload.code.status.ErrorStatus;
+
+public class LevelException extends GeneralException{
+    public LevelException(ErrorStatus errorStatus) { super(errorStatus); }
+}

--- a/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
+++ b/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
@@ -18,7 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     void addXpGauge(@Param("memberId") Long memberId, @Param("xp") int xp);
 
     @Modifying
-    @Query("UPDATE Member m SET m.level = :nextLevel WHERE m.id = :memberId")
+    @Query("UPDATE Member m SET m.level = :nextLevel, m.isQuizCompleted = false, m.isTutorialCompleted = false WHERE m.id = :memberId")
     void improveLevel(@Param("memberId") Long memberId, @Param("nextLevel")LevelType nextLevel);
 
     @Modifying

--- a/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
+++ b/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
@@ -28,4 +28,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying
     @Query("UPDATE Member m SET m.isQuizCompleted = true")
     void updateQuizStatus(boolean allQuizProblemsSolved);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.tokenBudget = m.tokenBudget + :rewardTokens WHERE m.id = :memberId")
+    void addRewardTokens(@Param("memberId") Long memberId, @Param("rewardTokens") int rewardTokens);
 }

--- a/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
+++ b/src/main/java/com/easystock/backend/infrastructure/database/repository/MemberRepository.java
@@ -24,4 +24,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Modifying
     @Query("UPDATE Member m SET m.isTutorialCompleted = true, m.tokenBudget = m.tokenBudget + :rewardTokens WHERE m.id = :memberId")
     void completeTutorialAndRewardTokens(@Param("memberId") Long memberId, @Param("rewardTokens") int rewardTokens);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.isQuizCompleted = true")
+    void updateQuizStatus(boolean allQuizProblemsSolved);
 }

--- a/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/level")
+@Tag(name = "레벨 API - /api/level ")
 public class LevelController {
     private final LevelService levelService;
     @PostMapping("/up")

--- a/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
@@ -23,7 +23,8 @@ public class LevelController {
     @PostMapping("/up")
     @Operation(
             summary = "회원 레벨업 API - 회원이 레벨업을 요청합니다.",
-            description = "회원이 레벨업을 요청합니다. 해당 레벨의 튜토리얼과 필수 퀴즈를 다 풀고, 경험치 기준을 충족하면 레벨업이 진행됩니다.",
+            description = "회원이 레벨업을 요청합니다. \s" +
+                    "해당 레벨의 튜토리얼과 필수 퀴즈를 다 풀고, 경험치 기준을 충족하면 레벨업이 진행됩니다. 레벨업 성공 시, 보상으로 3000STOKEN을 받습니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ApiResponse<LevelUpResponse> levelUp(

--- a/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/LevelController.java
@@ -1,0 +1,33 @@
+package com.easystock.backend.presentation.api.controller;
+
+import com.easystock.backend.application.service.level.LevelService;
+import com.easystock.backend.presentation.api.dto.response.LevelUpResponse;
+import com.easystock.backend.presentation.api.payload.ApiResponse;
+import com.easystock.backend.presentation.token.AuthUser;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/level")
+public class LevelController {
+    private final LevelService levelService;
+    @PostMapping("/up")
+    @Operation(
+            summary = "회원 레벨업 API - 회원이 레벨업을 요청합니다.",
+            description = "회원이 레벨업을 요청합니다. 해당 레벨의 튜토리얼과 필수 퀴즈를 다 풀고, 경험치 기준을 충족하면 레벨업이 진행됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    public ApiResponse<LevelUpResponse> levelUp(
+            @Parameter(hidden = true)
+            @AuthUser Long memberId){
+        return ApiResponse.onSuccess(levelService.levelUpIfPossible(memberId));
+    }
+
+}

--- a/src/main/java/com/easystock/backend/presentation/api/controller/MyPageController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/MyPageController.java
@@ -21,7 +21,7 @@ public class MyPageController {
     private final MyPageService myPageService;
     @GetMapping("/profile")
     @Operation(
-            summary = "유저 프로필 조회 API - 유저가 본인의 프로필을 조회합니다.",
+            summary = "회원 프로필 조회 API - 회원이 본인의 프로필을 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ApiResponse<GetMemberProfileResponse> getMyProfile(

--- a/src/main/java/com/easystock/backend/presentation/api/controller/QuizController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/QuizController.java
@@ -22,7 +22,7 @@ public class QuizController {
 
     @GetMapping("/problem-solve")
     @Operation(
-            summary = "퀴즈 조회 API - 유저가 레벨에 따른 퀴즈 정보를 조회합니다.",
+            summary = "퀴즈 조회 API - 회원이 레벨에 따른 퀴즈 정보를 조회합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ApiResponse<Quiz> getQuizProblems(
@@ -33,8 +33,8 @@ public class QuizController {
 
     @PostMapping("/{quizId}/submit")
     @Operation(
-            summary = "퀴즈 제출 API - 유저가 퀴즈에 대한 문제를 제출합니다.",
-            description = "유저가 풀고자 하는 퀴즈의 ID와 입력한 정답 인덱스를 요청 바디로 제출합니다.",
+            summary = "퀴즈 제출 API - 회원이 퀴즈에 대한 문제를 제출합니다.",
+            description = "회원이 풀고자 하는 퀴즈의 ID와 입력한 정답 인덱스를 요청 바디로 제출합니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ApiResponse<QuizSubmitResponse> submitQuizAnswer(

--- a/src/main/java/com/easystock/backend/presentation/api/controller/TradeController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/TradeController.java
@@ -24,7 +24,7 @@ public class TradeController {
 
     @GetMapping
     @Operation(
-            summary = "모든 거래 목록 조회 API - 로그인한 사용자의 모든 거래를 반환합니다.",
+            summary = "모든 거래 목록 조회 API - 회원의 모든 거래를 반환합니다.",
             security = @SecurityRequirement(name = "bearerAuth"))
     public ApiResponse<List<TradeResponse>> getAllTrades(
             @Parameter(hidden = true)

--- a/src/main/java/com/easystock/backend/presentation/api/controller/TradeController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/TradeController.java
@@ -28,18 +28,9 @@ public class TradeController {
             security = @SecurityRequirement(name = "bearerAuth"))
     public ApiResponse<List<TradeResponse>> getAllTrades(
             @Parameter(hidden = true)
-            @AuthUser Long memberId) {
-        return ApiResponse.onSuccess(tradeService.getAllTradesByUser(memberId));
-    }
-
-    @GetMapping
-    @Operation(
-            summary = "상태별 거래 목록 조회 API - 로그인한 사용자의 특정 상태에 따른 거래 목록을 반환합니다.",
-            security = @SecurityRequirement(name = "bearerAuth"))
-    public ApiResponse<List<TradeResponse>> getTradesByStatus(
-            @Parameter(hidden = true)
             @AuthUser Long memberId,
             @RequestParam(required = false) TradeStatus status) {
+        if(status == null) return ApiResponse.onSuccess(tradeService.getAllTradesByUser(memberId));
         return ApiResponse.onSuccess(tradeService.getTradesByStatus(memberId, status));
     }
 }

--- a/src/main/java/com/easystock/backend/presentation/api/controller/TutorialController.java
+++ b/src/main/java/com/easystock/backend/presentation/api/controller/TutorialController.java
@@ -25,7 +25,7 @@ public class TutorialController {
 
     @PostMapping("/complete")
     @Operation(
-            summary = "튜토리얼 완료하는 API - 특정 레벨의 튜토리얼 완료 후, 보상으로 1000 STOKEN을 받습니다.",
+            summary = "튜토리얼 완료 API - 특정 레벨의 튜토리얼 완료 후, 회원이 보상으로 1000 STOKEN을 받습니다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     public ApiResponse<CompleteTutorialResponse> completeTutorial(

--- a/src/main/java/com/easystock/backend/presentation/api/dto/converter/MemberConverter.java
+++ b/src/main/java/com/easystock/backend/presentation/api/dto/converter/MemberConverter.java
@@ -4,10 +4,7 @@ package com.easystock.backend.presentation.api.dto.converter;
 import com.easystock.backend.infrastructure.database.entity.Member;
 import com.easystock.backend.infrastructure.database.entity.enums.LevelType;
 import com.easystock.backend.presentation.api.dto.request.CreateMemberRequest;
-import com.easystock.backend.presentation.api.dto.response.CreateMemberResponse;
-import com.easystock.backend.presentation.api.dto.response.GetMemberProfileResponse;
-import com.easystock.backend.presentation.api.dto.response.LoginMemberResponse;
-import com.easystock.backend.presentation.api.dto.response.TokenResponse;
+import com.easystock.backend.presentation.api.dto.response.*;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
@@ -64,6 +61,13 @@ public class MemberConverter {
                 .level(member.getLevel())
                 .tokenBudget(member.getTokenBudget())
                 .xpGuage(member.getXpGauge())
+                .build();
+    }
+
+    public static LevelUpResponse toLevelUpResDto(LevelType nextLevel){
+        return LevelUpResponse.builder()
+                .levelType(nextLevel)
+                .message("축하합니다! 성공적으로 레벨업 되었습니다.")
                 .build();
     }
 }

--- a/src/main/java/com/easystock/backend/presentation/api/dto/converter/QuizConverter.java
+++ b/src/main/java/com/easystock/backend/presentation/api/dto/converter/QuizConverter.java
@@ -5,11 +5,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class QuizConverter {
-    public static QuizSubmitResponse toQuizSubmitResDto(boolean isCorrect, int addedXp, int totalXp) {
+    public static QuizSubmitResponse toQuizSubmitResDto(boolean isCorrect, boolean allQuizProblemsSolved, int addedXp, int totalXp) {
         String message = isCorrect
                 ? "정답입니다! " + addedXp + " 경험치가 추가되었습니다."
                 : "오답입니다. 다시 꼼꼼하게 읽고 풀어보세요!";
         return QuizSubmitResponse.builder()
+                .allQuizProblemsSolved(allQuizProblemsSolved)
                 .message(message)
                 .isCorrect(isCorrect)
                 .addedXp(addedXp)

--- a/src/main/java/com/easystock/backend/presentation/api/dto/response/LevelUpResponse.java
+++ b/src/main/java/com/easystock/backend/presentation/api/dto/response/LevelUpResponse.java
@@ -1,0 +1,18 @@
+package com.easystock.backend.presentation.api.dto.response;
+
+import com.easystock.backend.infrastructure.database.entity.enums.LevelType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class LevelUpResponse {
+    @Schema(description = "레벨업된 회원의 레벨")
+    private LevelType levelType;
+
+    @Schema(description = "레벨업 성공 메시지")
+    private String message;
+}

--- a/src/main/java/com/easystock/backend/presentation/api/dto/response/QuizSubmitResponse.java
+++ b/src/main/java/com/easystock/backend/presentation/api/dto/response/QuizSubmitResponse.java
@@ -10,12 +10,15 @@ public class QuizSubmitResponse {
     @Schema(description = "정답 여부")
     private boolean isCorrect;
 
-    @Schema(description = "사용자가 제출한 퀴즈 답변에 대한 반환값을 제공합니다.")
+    @Schema(description = "회원의 현재 레벨의 필수 퀴즈를 다 풀었는지 여부를 반환합니다.")
+    private boolean allQuizProblemsSolved;
+
+    @Schema(description = "회원이 제출한 퀴즈 답변에 대한 반환값을 제공합니다.")
     private String message;
 
     @Schema(description = "추가된 경험치")
     private int addedXp;
 
-    @Schema(description = "총 경험치")
+    @Schema(description = "회원의 총 경험치")
     private int totalXp;
 }

--- a/src/main/java/com/easystock/backend/presentation/api/payload/code/status/ErrorStatus.java
+++ b/src/main/java/com/easystock/backend/presentation/api/payload/code/status/ErrorStatus.java
@@ -39,7 +39,10 @@ public enum ErrorStatus implements BaseErrorCode {
     QUIZ_NOT_FOUND(HttpStatus.BAD_REQUEST, "QUIZ001", "해당하는 퀴즈 정보가 없습니다."),
 
     /* STOCK exception */
-    STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "STOCK001", "해당하는 주식 정보가 없습니다.");
+    STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "STOCK001", "해당하는 주식 정보가 없습니다."),
+
+    /* LEVEL exception */
+    LEVELUP_CONDITION_UNSATISFIED(HttpStatus.BAD_REQUEST, "LEVELUP001", "레벨업 조건 미충족으로 레벨업에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣ Issue Number
closed #22 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## 📝 요약(Summary)
- 기획 문서의 경험치 정책에 의한 레벨업 API 구현
> 해당 레벨 튜토리얼&퀴즈 완료 후, XP(경험치) 기준 충족 시 레벨업
> 레벨업 시 보상으로 3000 STOKEN 지급
- 그 외 자잘한 스웨거 문서 용어 통일
>  인증 정보가 필요없는 사용자 = '유저'
> 인증 정보가 있는 사용자 = '회원'


<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
### 회원 레벨업 요청 API - `/api/level/up`
![image](https://github.com/user-attachments/assets/8c90f46e-07ac-40f6-bcb2-a4ced4eac729)

200 OK 시, 회원의 현재 레벨보다 한 단계 높은 `ONE` 으로 레벨업이 되며, 회원의 총 자산도 이전보다 3000 STOKEN이 늘어납니다.
새로 레벨업이 되면, 현재 레벨인 `ONE` 의 튜토리얼과 퀴즈는 완료하지 못한 상태이므로 다시 `is_tutorial_completed` 와 `is_quiz_completed` 값은 false가 됩니다.

![image](https://github.com/user-attachments/assets/5f603586-e0a7-4e5c-b24b-924239c77f1b)

![image](https://github.com/user-attachments/assets/f887b5f3-3fa5-4240-830b-f668d53ac895)

## 💬 공유사항 to 리뷰어
생각보다 버그 해결 및 리팩터링되는 로직이 많아져서 PR단위가 커진 것 같아요 🤔😓
 커밋 별로 리뷰해주시면 감사하겠습니다! 🖐️
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
